### PR TITLE
Update selfservice.js

### DIFF
--- a/linotpd/src/linotp/public/js/selfservice.js
+++ b/linotpd/src/linotp/public/js/selfservice.js
@@ -770,7 +770,7 @@ $(document).ready(function() {
 
     $("#tabs").tabs({
         collapsible : true,
-        spinner : 'Retrieving data...',
+        // spinner : 'Retrieving data...',
         beforeLoad: function( event, ui ) {
             // The purpose of the following is to prevent automatic reloads
             // of the tab. When the tab loads for the first time the 'loaded'
@@ -778,6 +778,7 @@ $(document).ready(function() {
             // The tab can be reloaded by reloading the whole page
             // Tab Option 'cache: true' (used before for this same purpose)
             // was removed in jQuery UI version 1.10
+            ui.panel.html('<img src="/images/ajax-loader.gif"/> Retrieving data...');
             if ( ui.tab.data( "loaded" )  ) {
                 event.preventDefault();
             }


### PR DESCRIPTION
spinner has been deprecated in jquery 1.10, so it is no longer obvious if a tab is being loaded after clicking on it.
fix it several lines bellow with ui.panel.html()
