### PR TITLE
Update hmactoken.mako

### DIFF
--- a/linotpd/src/linotp/lib/tokens/hmactoken.mako
+++ b/linotpd/src/linotp/lib/tokens/hmactoken.mako
@@ -349,7 +349,7 @@ $( document ).ready(function() {
 });
 
 </script>
-<h2>${_("Enroll your HOTP token")}</h2>
+<h1>${_("Enroll your HOTP token")}</h1>
 <div id='enroll_hmac_form'>
     <form class="cmxform" id='form_enroll_hmac'>
     <fieldset>


### PR DESCRIPTION
Headers should be size 1 which is the case with all the other tabs in the SelfService Portal
