### PR TITLE
Update totptoken.mako

### DIFF
--- a/linotpd/src/linotp/lib/tokens/totptoken.mako
+++ b/linotpd/src/linotp/lib/tokens/totptoken.mako
@@ -438,7 +438,7 @@ $( document ).ready(function() {
 });
 
 </script>
-<h2>${_("Enroll your TOTP token")}</h2>
+<h1>${_("Enroll your TOTP token")}</h1>
 <div id='enroll_totp_form'>
     <form class="cmxform" id='form_enroll_totp'>
     <fieldset>


### PR DESCRIPTION
Headers should be size 1 which is the case with all the other tabs in the SelfService Portal
