### PR TITLE
 spass: allow for one-time tokens creation

### DIFF
--- a/linotpd/src/linotp/lib/tokens/spasstoken.py
+++ b/linotpd/src/linotp/lib/tokens/spasstoken.py
@@ -108,6 +108,10 @@ class SpassTokenClass(TokenClass):
         if not param.has_key('otpkey'):
             param['genkey'] = 1
 
+        ## mark this spass token as usable exactly once
+        if param.has_key('onetime'):
+            TokenClass.set_count_auth_success_max(self, 1)
+
         TokenClass.update(self, param)
 
     ## the spass token does not suport challenge response


### PR DESCRIPTION
This PR adds an optional parameter to allow creation of simple pass tokens that can be used exactly once. Those can be useful as backup/recovery codes that can be self-provisioned in advance by users.