### PR TITLE
oath tokens: add issuer label for otp applications

### DIFF
--- a/linotpd/src/linotp/lib/apps.py
+++ b/linotpd/src/linotp/lib/apps.py
@@ -40,7 +40,7 @@ import urllib
 import logging
 log = logging.getLogger(__name__)
 
-from linotp.lib.policy import get_tokenlabel
+from linotp.lib.policy import get_tokenlabel, get_tokenissuer
 from urllib import quote
 
 class NoOtpAuthTokenException(Exception):
@@ -104,6 +104,10 @@ def create_google_authenticator(param, user=None, context=None):
     if 'timeStep' in param:
         url_param['period'] = param.get('timeStep')
 
+    issuer = get_tokenissuer(login, realm, serial, context=context)
+    if issuer:
+        url_param['issuer'] = quote(issuer)
+
     ga = "otpauth://%s/%s" % (typ, serial)
     qg_param = urllib.urlencode(url_param)
 
@@ -125,8 +129,10 @@ def create_google_authenticator(param, user=None, context=None):
         if len(param.get('description', '')) > 0:
             label = label + ':' + param.get('description')
 
+    if issuer:
+        label = issuer + ':' + label
     label = label[0:allowed_label_len]
-    url_label = quote(label)
+    url_label = quote(label, ':')
 
     ga = "otpauth://%s/%s?%s" % (typ, url_label, qg_param)
     log.debug("google authenticator: %r" % ga[:20])

--- a/linotpd/src/linotp/lib/policy/__init__.py
+++ b/linotpd/src/linotp/lib/policy/__init__.py
@@ -680,6 +680,34 @@ def _checkTokenAssigned(user, context=None):
     return False
 
 
+def get_tokenissuer(user="", realm="", serial="", context=None):
+    '''
+    This internal function returns the issuer of the token as defined in policy
+    scope = enrollment, action = tokenissuer = <string>
+    The string can have the following variables:
+        <u>: user
+        <r>: realm
+        <s>: token serial
+
+    This function is used to create 'otpauth' tokens
+    '''
+    tokenissuer = ""
+    client = _get_client(context)
+    pol = get_client_policy(client, scope="enrollment",
+                            realm=realm, user=user,
+                            context=context)
+    if len(pol) != 0:
+        string_issuer = getPolicyActionValue(pol, "tokenissuer", String=True)
+        if string_issuer:
+            string_issuer = re.sub('<u>', user, string_issuer)
+            string_issuer = re.sub('<r>', realm, string_issuer)
+            string_issuer = re.sub('<s>', serial, string_issuer)
+            tokenissuer = string_issuer
+
+    log.debug("[get_tokenissuer] providing tokenissuer = %s" % str(tokenissuer))
+    return tokenissuer
+
+
 def get_tokenlabel(user="", realm="", serial="", context=None):
     '''
     This internal function returns the naming of the token as defined in policy

--- a/linotpd/src/linotp/lib/policy/definitions.py
+++ b/linotpd/src/linotp/lib/policy/definitions.py
@@ -126,6 +126,9 @@ def getPolicyDefinitions(scope=""):
             'tokenlabel': {
                 'type': 'str',
                 'desc': 'the label for the google authenticator.'},
+            'tokenissuer': {
+                 'type': 'str',
+                 'desc': 'the issuer label for the google authenticator.'},
 
             'autoenrollment': {
                 'type': 'str',


### PR DESCRIPTION
This PR adds a new `tokenissuer` policy element (and related tests) that can be used to set the issuer portion of an OATH token in soft-tokens applications (similarly to the existing `tokenlabel` policy).
Implementation follows the the `otpauth://` [URI format specification](https://github.com/google/google-authenticator/wiki/Key-Uri-Format).

This has been tested on FreeOTP and GoogleAuthenticator as shown below:

![gauth-issuer](https://cloud.githubusercontent.com/assets/98086/8778527/bc3d55ce-2efe-11e5-9ba3-144b798c6b64.png)
![freeotp-issuer](https://cloud.githubusercontent.com/assets/98086/8778521/b5781e22-2efe-11e5-8dc4-f8b0208f2e6e.png)
