### PR TITLE
lost token: do not copy old pin on lost spass

### DIFF
--- a/linotpd/src/linotp/auth/validate.py
+++ b/linotpd/src/linotp/auth/validate.py
@@ -535,13 +535,15 @@ class FinishTokens(object):
             self.create_audit_entry(detail, self.challenge_tokens)
             return ret, reply
 
+        failed_tokens = self.pin_matching_tokens + self.invalid_tokens
         if self.user:
             log.warning("user %r@%r failed to auth."
                         % (self.user.login, self.user.realm))
-        else:
+        elif failed_tokens:
             log.warning("serial %r failed to auth."
-                        % (self.pin_matching_tokens +
-                           self.invalid_tokens)[0].getSerial())
+                        % failed_tokens[0].getSerial())
+        else:
+            log.warning("generic authentication failure.")
 
         if self.pin_matching_tokens:
             (ret, reply, detail) = self.finish_pin_matching_tokens()

--- a/linotpd/src/linotp/lib/token.py
+++ b/linotpd/src/linotp/lib/token.py
@@ -425,8 +425,13 @@ class TokenHandler(object):
 
         res['init'] = ret
         if True == ret:
+            # copy the assigned user
             res['user'] = self.copyTokenUser(serial, new_serial)
-            res['pin'] = self.copyTokenPin(serial, new_serial)
+
+            # copy the pin, except for spass
+            # (because the pin is the spass password, and the user lost it)
+            if getTokenType(serial) not in ["spass"]:
+                res['pin'] = self.copyTokenPin(serial, new_serial)
 
             # set validity period
             end_date = (datetime.date.today()


### PR DESCRIPTION
During lost-token generation, the old pin is copied over.
However, in the case of spass token the pin is used as password, and the user has lost it.

This PR avoids copying the old pin on lost spass events, to make the new password alone usable when the previous spass-pin is not anymore available.
It also fixes a logging exception, reachable via `check_s()` on a disabled token.

The whole testsuite passes without issues, and a dedicated test for lost spass is introduced as well.

/cc @gvarisco @giobbe

Signed-off-by: Luca Bruno <luca.bruno@rocket-internet.de>