### PR TITLE
config: add enableReplication option to example doc

### DIFF
--- a/linotpd/src/config/linotp.ini.example
+++ b/linotpd/src/config/linotp.ini.example
@@ -119,6 +119,7 @@ linotp.DefaultResetFailCount = True
 linotp.splitAtSign = True
 
 linotpGetotp.active = False
+linotp.enableReplication = False
 
 ## Encrytion key:
 ## --------------

--- a/linotpd/src/config/linotp.ini.paster
+++ b/linotpd/src/config/linotp.ini.paster
@@ -50,6 +50,7 @@ linotpAudit.sql.highwatermark = 10000
 linotpAudit.sql.lowwatermark = 5000
 
 linotpGetotp.active = False
+linotp.enableReplication = False
 
 linotp.DefaultSyncWindow = 1000
 linotp.DefaultOtpLen = 6


### PR DESCRIPTION
The 'enableReplication' configuration parameter is not documented
anywhere, yet clustered setups can break in subtle ways without it.

Adding this option (disabled) to the configuration examples could
help avoiding operational issues and save some debugging time :)

Signed-off-by: Luca Bruno luca.bruno@rocket-internet.de
