### PR TITLE
fixed inconsistent return type

### DIFF
--- a/linotpd/src/linotp/lib/security/provider.py
+++ b/linotpd/src/linotp/lib/security/provider.py
@@ -409,7 +409,7 @@ class SecurityProvider(object):
                     locked = False
                     retry = False
                     log.debug("[getSecurityModule] using existing pool session %s" % found)
-                    return found.get('obj')
+                    return found
                 else:
                     ## create new entry
                     log.debug("[getSecurityModule] getting new Session (%s) "


### PR DESCRIPTION
I found this inconsistency causing undue authentication failures (related to https://github.com/LinOTP/LinOTP/issues/49 and  https://github.com/LinOTP/LinOTP/issues/61)