### PR TITLE
Bug found in Challenge object using Oracle

### DIFF
--- a/linotpd/src/linotp/model/__init__.py
+++ b/linotpd/src/linotp/model/__init__.py
@@ -1070,7 +1070,8 @@ class Challenge(object):
 
         :return: success - boolean
         """
-        if self.session == '':
+        # Added check for the null case
+        if not(self.session) or self.session == '':
             self.session = '{}'
         session = json.loads(self.session)
         status = session.get('status', 'open')
@@ -1168,6 +1169,11 @@ challenge_mapping['ochallenge'] = challenges_table.c.challenge
 
 # new challenge column point now to the challenge member
 challenge_mapping['challenge'] = challenges_table.c.lchallenge
+
+# Added mapping for session and timestamp columns
+challenge_mapping['timestamp'] = challenges_table.c.get(timestamp_column)
+challenge_mapping['session'] = challenges_table.c.get(session_column)
+
 orm.mapper(Challenge, challenges_table, properties=challenge_mapping,)
 
 


### PR DESCRIPTION
My configuration is:

SO: CentOs7
LinOTP: 2.10.0.3 (installed via RPM found at http://linotp.org/rpm/el7/linotp/x86_64/Packages/LinOTP_repos-1.1-1.el7.x86_64.rpm)
SQLAlchemy: 1.2.6
cx-Oracle: 6.2.1
python: 2.7.5
DB: Oracle 12.2.0.1.0

When using Oracle, LinOTP changes timestamp and session column names of the tables Challenge and Ocra with linotimestamp and linosession respectively.
I confirm that LinOTP created in my DB the right column names (i.e. linotimestamp and linosession).

But when I try to create a challenge I get the following error:

ERROR [linotp.controllers.validate][check #262] [check] validate/check failed: TypeError("unsupported operand type(s) for +: 'NoneType' and 'datetime.timedelta'",)
lib/challenges.py: line: #348
#347 c_start_time = challenge.get('timestamp')
#348 c_expire_time = c_start_time + datetime.timedelta(seconds=validity)

I found that challenge.get('timestamp') returns a null value because the object doesn't contain a field called 'timestamp', but it contains a field called 'linotimestamp' that contains a non-null value (the timestamp of the challenge creation event, i.e. the right value).

The same problem applies for the field 'session' of the challenge object.

I believe that the bug is in model/__init__.py, where the challenge class is defined.
It seems that for the fields above is not defined the right specific orm mapping, so it applies the default mapping between columns and fields: the column 'linotimestamp' is mapped to the field linotimestamp of the challenge object. (the same for the session field).

Adding the specific mapping after line #1170 (before the orm.mapper method call):

#1171 challenge_mapping['timestamp'] = challenges_table.c.get(timestamp_column)
#1172 challenge_mapping['session'] = challenges_table.c.get(session_column)

solves the problem. 

Surprisingly, in the end of model/__init__.py, I found that the same mapping is defined only for the ocra table / OcraChallenge class (lines #1294 - #1307).
 
P.S. I modified also line #1073 (Challenge.is_open method) to deal with the null/empty session case, that seems to happen with Oracle db:

#1073 if not(self.session) or self.session == '':

I hope that you consider my pull request and fix this issue in your future releases. 

Best Regards

Roberto