### PR TITLE
Change yubico API url to https as http is being deprecated

### DIFF
--- a/linotpd/src/linotp/tokens/yubicotoken.py
+++ b/linotpd/src/linotp/tokens/yubicotoken.py
@@ -40,7 +40,7 @@ from linotp.lib.error import ParameterError
 
 YUBICO_LEN_ID = 12
 YUBICO_LEN_OTP = 44
-YUBICO_URL = "http://api.yubico.com/wsapi/2.0/verify"
+YUBICO_URL = "https://api.yubico.com/wsapi/2.0/verify"
 DEFAULT_CLIENT_ID = 11759
 DEFAULT_API_KEY = "P1QVTgnToQWQm0b6LREEhDIAbHU="
 


### PR DESCRIPTION
Yubico are dropping support for plan-text requests soon. This has already started affecting us as we are regularly getting errors such as:

`[checkOtp] Error getting response from Yubico Cloud Server ('http://api.yubico.com/wsapi/2.0/verify?nonce=xxxxxxxxxxxxxxx=xxxxxxxxxxxxxxxxx&id=xxxxxx'): HTTPError()`
The server responds with a HTTP 410 error.

Contacting yubico support they pointed me in the direction of this [support page](https://status.yubico.com/2018/11/26/deprecating-yubicloud-v1-protocol-plain-text-requests-and-old-tls-versions/)

They suggested switching over to https would sort these errors. I have not seen the above error since using the https URL on our LinOTP server.