### PR TITLE
Use notify_all instead of notifyAll method that was deprecated in Python 3.10.

### DIFF
--- a/linotp/lib/rw_lock.py
+++ b/linotp/lib/rw_lock.py
@@ -99,7 +99,7 @@ class RWLock:
         """Demote an already-acquired write lock to a read lock"""
         self.monitor.acquire()
         self.rwlock = 1
-        self.readers_ok.notifyAll()
+        self.readers_ok.notify_all()
         self.monitor.release()
 
     def release(self):
@@ -118,5 +118,5 @@ class RWLock:
             self.writers_ok.release()
         elif wake_readers:
             self.readers_ok.acquire()
-            self.readers_ok.notifyAll()
+            self.readers_ok.notify_all()
             self.readers_ok.release()


### PR DESCRIPTION
Camel case methods were deprecated in Python 3.10 in https://github.com/python/cpython/pull/25174