### PR TITLE
Docker build fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -130,7 +130,7 @@ RUN test -z "$DEPENDENCY_DEB_REPO" \
     || (echo "deb $DEPENDENCY_DEB_REPO" > /etc/apt/sources.list.d/linotp-deps.list \
     && cat /etc/apt/sources.list.d/linotp-deps.list)
 
-# RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys $DEPENDENCY_GPG_KEYID
+RUN apt install ca-certificates
 RUN test -z "$DEPENDENCY_GPG_KEYID" \
     || apt-key adv --keyserver keyserver.ubuntu.com --recv-keys $DEPENDENCY_GPG_KEYID
 RUN test -z "$DEPENDENCY_GPG_KEY_URL" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -131,8 +131,8 @@ RUN test -z "$DEPENDENCY_DEB_REPO" \
     && cat /etc/apt/sources.list.d/linotp-deps.list)
 
 RUN apt install ca-certificates
-RUN test -z "$DEPENDENCY_GPG_KEYID" \
-    || apt-key adv --keyserver keyserver.ubuntu.com --recv-keys $DEPENDENCY_GPG_KEYID
+RUN curl https://dist.linotp.org/debian/gpg-keys/linotp-archive-current.asc | tee /etc/apt/trusted.gpg.d/linotp-archive-current.asc
+
 RUN test -z "$DEPENDENCY_GPG_KEY_URL" \
     || curl $DEPENDENCY_GPG_KEY_URL | apt-key adv --import
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -129,8 +129,10 @@ RUN apt-get update && apt-get install eatmydata \
 RUN test -z "$DEPENDENCY_DEB_REPO" \
     || (echo "deb $DEPENDENCY_DEB_REPO" > /etc/apt/sources.list.d/linotp-deps.list \
     && cat /etc/apt/sources.list.d/linotp-deps.list)
+
+# RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys $DEPENDENCY_GPG_KEYID
 RUN test -z "$DEPENDENCY_GPG_KEYID" \
-    || apt-key adv --keyserver hkp://hkps.pool.sks-keyservers.net --recv-keys $DEPENDENCY_GPG_KEYID
+    || apt-key adv --keyserver keyserver.ubuntu.com --recv-keys $DEPENDENCY_GPG_KEYID
 RUN test -z "$DEPENDENCY_GPG_KEY_URL" \
     || curl $DEPENDENCY_GPG_KEY_URL | apt-key adv --import
 

--- a/Makefile
+++ b/Makefile
@@ -282,6 +282,7 @@ DOCKER_BUILDDIR=$(BUILDDIR)/linotpd.build
 
 .PHONY: docker-build-debs
 docker-build-debs: docker-build-linotp-builder
+	mkdir -p $(BUILDDIR)
 	# Force rebuild of debs
 	rm -f $(BUILDDIR)/apt/Packages
 	$(MAKE) $(BUILDDIR)/apt/Packages

--- a/Makefile
+++ b/Makefile
@@ -202,8 +202,8 @@ DEBIAN_MIRROR=deb.debian.org
 
 # Override to change the dependency repository used to install required packages
 ifndef DEPENDENCY_DEB_REPO
-DEPENDENCY_DEB_REPO=http://www.linotp.org/apt/debian buster linotp
-DEPENDENCY_GPG_KEYID=913DFF12F86258E5
+DEPENDENCY_DEB_REPO=http://dist.linotp.org/debian/linotp3 buster linotp
+DEPENDENCY_GPG_KEYID=D89DAB182B27E629
 endif
 
 # Override to change the Debian release used to build with


### PR DESCRIPTION
`docker-build-all` didn't work, so I made several fixes:
- create a missing `build` directory
- use actual linotp repo and pgp key